### PR TITLE
Updated reference to method in example docstring

### DIFF
--- a/docs/gallery/pca/plot_017_2d_scores_loadings_legend.py
+++ b/docs/gallery/pca/plot_017_2d_scores_loadings_legend.py
@@ -9,7 +9,7 @@ also show the loadings. Here we show labels in a legend, rather
 than in the plot, to avoid making the plot too crowded.
 
 For better results, the parameter ``savefig`` can be used
-when calling meth:`.pca_2d_scores` to store the plot directly to a
+when calling :meth:`.pca_2d_scores` to store the plot directly to a
 file. In this case, the plot is better adjusted to accompany all
 elements.
 """


### PR DESCRIPTION
This PR adds a missing ":" to a docstring.