### PR TITLE
Updated variance deprecation warning and docstrings.

### DIFF
--- a/docs/gallery/pca/plot_006_explained_variance_join.py
+++ b/docs/gallery/pca/plot_006_explained_variance_join.py
@@ -38,8 +38,15 @@ fig, (ax1, ax2) = plt.subplots(
 pca_explained_variance_bar(pca, axi=ax1, alpha=0.8)
 pca_explained_variance(pca, axi=ax2, marker='o', markersize=16, alpha=0.8)
 ax4 = ax2.twinx()
-pca_residual_variance(pca, ax4, marker='X', markersize=16, alpha=0.8,
-                      color='black', linestyle='--')
+pca_residual_variance(
+    pca,
+    ax4,
+    marker='X',
+    markersize=16,
+    alpha=0.8,
+    color='black',
+    linestyle='--'
+)
 ax3 = inset_axes(ax1, width='45%', height='45%', loc=9)
 pca_explained_variance_pie(pca, axi=ax3, cmap='tab20')
 

--- a/docs/gallery/pca/plot_007_1d_loadings_bar.py
+++ b/docs/gallery/pca/plot_007_1d_loadings_bar.py
@@ -22,11 +22,12 @@ data = scale(data)
 pca = PCA()
 pca.fit_transform(data)
 
-pca_1d_loadings(pca, data_set['feature_names'], select_components={2},
-                plot_type='bar')
-pca_1d_loadings(pca, data_set['feature_names'], select_components={2},
-                plot_type='bar-square')
-pca_1d_loadings(pca, data_set['feature_names'], select_components={2},
-                plot_type='bar-absolute')
+for plot_type in ('bar', 'bar-square', 'bar-absolute'):
+    pca_1d_loadings(
+        pca,
+        data_set['feature_names'],
+        select_components={2},
+        plot_type=plot_type,
+    )
 
 plt.show()

--- a/docs/gallery/pca/plot_008_variable_contributions.py
+++ b/docs/gallery/pca/plot_008_variable_contributions.py
@@ -34,18 +34,30 @@ kwargs = {
 
 
 # Plot the value of the coefficients:
-pca_loadings_map(pca, data_set['feature_names'],
-                 textcolors=['white', 'black'], **kwargs)
+pca_loadings_map(
+    pca,
+    data_set['feature_names'],
+    textcolors=['white', 'black'],
+    **kwargs
+)
 
 # Plot the absolute value of the coefficients:
 kwargs['heatmap']['vmin'] = 0
-pca_loadings_map(pca, data_set['feature_names'],
-                 textcolors=['white', 'black'],
-                 plot_style='absolute', **kwargs)
+pca_loadings_map(
+    pca,
+    data_set['feature_names'],
+    textcolors=['white', 'black'],
+    plot_style='absolute',
+    **kwargs
+)
 
 # Plot the squared value of the coefficients:
-pca_loadings_map(pca, data_set['feature_names'],
-                 textcolors=['white', 'black'],
-                 plot_style='squared', **kwargs)
+pca_loadings_map(
+    pca,
+    data_set['feature_names'],
+    textcolors=['white', 'black'],
+    plot_style='squared',
+    **kwargs
+)
 
 plt.show()

--- a/docs/gallery/pca/plot_009_variable_contributions_bubble.py
+++ b/docs/gallery/pca/plot_009_variable_contributions_bubble.py
@@ -32,10 +32,23 @@ kwargs = {
 
 
 # Plot the value of the coefficients:
-pca_loadings_map(pca, data_set['feature_names'],
-                 bubble=True, annotate=False, **kwargs)
+pca_loadings_map(
+    pca,
+    data_set['feature_names'],
+    bubble=True,
+    annotate=False,
+    **kwargs
+)
+
 # Plot the absolute value of the coefficients:
 kwargs['heatmap']['vmin'] = 0
-pca_loadings_map(pca, data_set['feature_names'],
-                 bubble=True, annotate=False, plot_style='absolute', **kwargs)
+pca_loadings_map(
+    pca,
+    data_set['feature_names'],
+    bubble=True,
+    annotate=False,
+    plot_style='absolute',
+    **kwargs
+)
+
 plt.show()

--- a/docs/gallery/pca/plot_010_1d_loadings.py
+++ b/docs/gallery/pca/plot_010_1d_loadings.py
@@ -21,12 +21,14 @@ data = scale(data)
 pca = PCA()
 pca.fit_transform(data)
 
-text_settings = {
-    'fontsize': 'x-large',
-    'weight': 'bold',
-}
-
-pca_1d_loadings(pca, data_set['feature_names'], select_components={2},
-                text_settings=text_settings)
+pca_1d_loadings(
+    pca,
+    data_set['feature_names'],
+    select_components={2},
+    text_settings={
+        'fontsize': 'x-large',
+        'weight': 'bold',
+    },
+)
 
 plt.show()

--- a/docs/gallery/pca/plot_011_2d_loadings.py
+++ b/docs/gallery/pca/plot_011_2d_loadings.py
@@ -21,12 +21,16 @@ data = scale(data)
 pca = PCA()
 pca.fit_transform(data)
 
-text_settings = {'fontsize': 'x-large',
-                 'outline': {'foreground': '0.8'}}
+text_settings = {
+    'fontsize': 'xx-large',
+    'outline': {'foreground': '0.2'}
+}
 
-pca_2d_loadings(pca, data_set['feature_names'],
-                select_components={(3, 4)},
-                adjust_labels=True,
-                text_settings=text_settings)
+pca_2d_loadings(
+    pca,
+    data_set['feature_names'],
+    select_components={(3, 4)},
+    text_settings=text_settings
+)
 
 plt.show()

--- a/docs/gallery/pca/plot_012_3d_loadings.py
+++ b/docs/gallery/pca/plot_012_3d_loadings.py
@@ -22,16 +22,28 @@ pca = PCA()
 pca.fit_transform(data)
 
 
-pca_3d_loadings(pca, data_set['feature_names'],
-                select_components={(1, 2, 3)})
+# Plot the loadings for 3 principal components:
+pca_3d_loadings(
+    pca,
+    data_set['feature_names'],
+    select_components={(1, 2, 3)}
+)
 
 
-text_settings = {'fontsize': 'xx-large', 'weight': 'bold',
-                 'outline': {'linewidth': 0.5}}
+# Modify the text settings and plot the loadings
+# for 3 principal components:
+text_settings = {
+    'fontsize': 'xx-large',
+    'weight': 'bold',
+    'outline': {'linewidth': 0.5}
+}
 
-pca_3d_loadings(pca, data_set['feature_names'],
-                select_components={(1, 2, 3)},
-                cmap='Spectral',
-                text_settings=text_settings)
+pca_3d_loadings(
+    pca,
+    data_set['feature_names'],
+    select_components={(1, 2, 3)},
+    cmap='Spectral',
+    text_settings=text_settings
+)
 
 plt.show()

--- a/docs/gallery/styling/plot_001_2d_loadings_xkcd.py
+++ b/docs/gallery/styling/plot_001_2d_loadings_xkcd.py
@@ -5,9 +5,10 @@ PCA Loadings (2D) with xkcd style and centered axes
 ===================================================
 
 This example will plot PCA loadings along two principal axes.
-Here we employ the xkcd style and also modify the loadings
-plot to use centered axes (that is, the axes go through
-the origin).
+Here we employ the
+`xkcd style <https://matplotlib.org/gallery/showcase/xkcd.html>`_
+and also modify the loadings plot to use centered axes
+(that is, the axes go through the origin).
 """
 from matplotlib import pyplot as plt
 import pandas as pd
@@ -24,9 +25,11 @@ data = scale(data)
 pca = PCA()
 pca.fit_transform(data)
 
-pca_2d_loadings(pca, data_set['feature_names'],
-                select_components={(1, 2)},
-                adjust_labels=True,
-                style='center')
+pca_2d_loadings(
+    pca,
+    data_set['feature_names'],
+    select_components={(1, 2)},
+    style='center'
+)
 
 plt.show()

--- a/docs/gallery/styling/plot_003_custom_color_map.py
+++ b/docs/gallery/styling/plot_003_custom_color_map.py
@@ -75,7 +75,7 @@ figures, axes = pca_2d_scores(
     scores,
     class_data=class_data,
     class_names=class_names,
-    select_components={(1, 2),},
+    select_components={(1, 2)},
     s=200,
     alpha=.8,
     cmap_class=dompap,
@@ -87,7 +87,10 @@ _, axi = pca_explained_variance_pie(pca, cmap=colorbrewer)
 axi.set_title('Using a colorbrewer color map:')
 
 _, axes = pca_1d_loadings(
-    pca, data_set['feature_names'], select_components={1,}, cmap=bold,
+    pca,
+    data_set['feature_names'],
+    select_components={1},
+    cmap=bold,
     text_settings={'weight': 'bold', 'fontsize': 'x-large'}
 )
 axes[0].set_title('Loadings with the "bold" color map:')

--- a/psynlig/pca/variance.py
+++ b/psynlig/pca/variance.py
@@ -209,6 +209,7 @@ def pca_explained_variance_pie(pca, axi=None, figsize=None,
         colors=colors[:len(comp)],
         wedgeprops=dict(width=0.5, edgecolor='w'),
         textprops={'fontsize': 'x-large'},
+        normalize=False,
     )
     axi.set(aspect='equal')
     return fig, axi


### PR DESCRIPTION
This PR will remove a matplotlib deprecation warning by turning off normalization for the pie chart.

Also, some example code-style updates.